### PR TITLE
Modify Goal/Quest interface

### DIFF
--- a/api_documentation/business_progress/goals/add.md
+++ b/api_documentation/business_progress/goals/add.md
@@ -25,7 +25,7 @@ Success Response:
   "updated_goals": Array[{
       "id": UUID,
       "name": string,
-      "goal_or_quest": string, // "Goal" | "Quest"
+      "goal_or_quest": "Goal",
       "unit": string,
       "target": float,
       "current_progress": float,

--- a/api_documentation/business_progress/goals/edit.md
+++ b/api_documentation/business_progress/goals/edit.md
@@ -26,7 +26,7 @@ Success Response:
   "updated_goals": Array[{
       "id": UUID,
       "name": string,
-      "goal_or_quest": string, // "Goal" | "Quest"
+      "goal_or_quest": "Goal",
       "unit": string,
       "target": float,
       "current_progress": float,

--- a/api_documentation/business_progress/goals/remove.md
+++ b/api_documentation/business_progress/goals/remove.md
@@ -21,7 +21,7 @@ Success Response:
   "updated_goals": Array[{
       "id": UUID,
       "name": string,
-      "goal_or_quest": string, // "Goal" | "Quest"
+      "goal_or_quest": "Goal",
       "unit": string,
       "target": float,
       "current_progress": float,


### PR DESCRIPTION
While Goals and Quests have the same data structure, their interactions are different.

For goals, the user can add, edit, remove, and also view.

For quests, it is just view.

Therefore, we should just return the updated goals (without quests) when adding/editing/removing a goal.